### PR TITLE
Tweaks following review

### DIFF
--- a/shell/components/DetailTop.vue
+++ b/shell/components/DetailTop.vue
@@ -3,7 +3,6 @@ import Tag from '@shell/components/Tag';
 import isEmpty from 'lodash/isEmpty';
 import DetailText from '@shell/components/DetailText';
 import { _VIEW } from '@shell/config/query-params';
-import { pickBy } from 'lodash';
 
 export const SEPARATOR = { separator: true };
 
@@ -98,8 +97,12 @@ export default {
       return this.value?.filteredSystemLabels;
     },
 
-    filteredLabels() {
-      return pickBy(this.labels, (_, key) => !this.value.getPSALabelsNamespaceVersion.includes(key));
+    internalTooltips() {
+      return this.value?.detailTopTooltips || this.tooltips;
+    },
+
+    internalIcons() {
+      return this.value?.detailTopIcons || this.icons;
     },
 
     annotations() {
@@ -224,19 +227,19 @@ export default {
           {{ t('resourceDetail.detailTop.labels') }}:
         </span>
         <Tag
-          v-for="(prop, key) in filteredLabels"
+          v-for="(prop, key) in labels"
           :key="key + prop"
         >
           <i
-            v-if="icons[key]"
+            v-if="internalIcons[key]"
             class="icon"
-            :class="icons[key]"
+            :class="internalIcons[key]"
           />
           <span
-            v-if="tooltips[key]"
+            v-if="internalTooltips[key]"
             v-tooltip="prop ? `${key} : ${prop}` : key"
           >
-            <span>{{ tooltips[key] ? tooltips[key] : key }}</span>
+            <span>{{ internalTooltips[key] ? internalTooltips[key] : key }}</span>
           </span>
           <span v-else>{{ prop ? `${key} : ${prop}` : key }}</span>
         </Tag>

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -237,10 +237,10 @@ export default {
   },
   methods: {
     getPSA(row) {
-      const dictionary = row.getPSATooltipsDescription();
+      const dictionary = row.psaTooltipsDescription;
       const list = values(dictionary).map(text => `<li>${ text }</li>`).join('');
 
-      return `<ul class="mr-30">${ list }</ul>`;
+      return `<ul class="psa-tooltip">${ list }</ul>`;
     },
 
     userIsFilteringForSpecificNamespaceOrProject() {
@@ -396,16 +396,18 @@ export default {
         >&ndash;</span>
       </template>
       <template #cell:name="{row}">
-        <n-link
-          :to="row.detailLocation"
-        >
-          {{ row.name }}
-        </n-link>
-        <i
-          v-if="row.hasPSALabels"
-          v-tooltip="getPSA(row)"
-          class="icon icon-lock"
-        />
+        <div class="namespace-name">
+          <n-link
+            :to="row.detailLocation"
+          >
+            {{ row.name }}
+          </n-link>
+          <i
+            v-if="row.hasSystemLabels"
+            v-tooltip="getPSA(row)"
+            class="icon icon-lock ml-5"
+          />
+        </div>
       </template>
       <template
         v-for="project in projectsWithoutNamespaces"
@@ -468,6 +470,19 @@ export default {
         }
       }
     }
+
+    .namespace-name {
+      display: flex;
+      align-items: center;
+    }
   }
 }
+</style>
+<style lang="scss">
+  .psa-tooltip {
+    // These could pop up a lot as the mouse moves around, keep them as small and unintrusive as possible
+    // (easier to test with v-tooltip="{ content: getPSA(row), autoHide: false, show: true }")
+    margin: 3px 0;
+    padding: 0 8px 0 22px;
+  }
 </style>

--- a/shell/components/PodSecurityAdmission.vue
+++ b/shell/components/PodSecurityAdmission.vue
@@ -139,7 +139,7 @@ export default Vue.extend({
 </script>
 
 <template>
-  <div>
+  <div class="psa">
     <!-- PSA -->
     <p class="helper-text mb-30">
       <t k="podSecurityAdmission.description" />
@@ -150,7 +150,7 @@ export default Vue.extend({
       :key="'control-' + i"
       class="row row--y-center mb-20"
     >
-      <span class="col span-2">
+      <span class="col span-2 psa-checkbox">
         <Checkbox
           v-model="control.active"
           :data-testid="componentTestid + '--' + i + '-active'"
@@ -224,3 +224,12 @@ export default Vue.extend({
     </template>
   </div>
 </template>
+
+<style lang="scss" scoped>
+.psa .row {
+    .psa-checkbox {
+      display: flex;
+      align-items: center;
+    }
+}
+</style>

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -13,7 +13,6 @@ import DetailTop from '@shell/components/DetailTop';
 import { clone, diff } from '@shell/utils/object';
 import IconMessage from '@shell/components/IconMessage';
 import ForceDirectedTreeChart from '@shell/components/fleet/ForceDirectedTreeChart';
-import { PSAIconsDisplay } from '@shell/config/pod-security-admission';
 
 function modeFor(route) {
   if ( route.query?.mode === _IMPORT ) {
@@ -225,14 +224,11 @@ export default {
     if ( this.mode === _CREATE ) {
       this.value.applyDefaults(this, realMode);
     }
-    this.tooltipsDescription = this.value.getPSATooltipsDescription(this.liveModel);
   },
   data() {
     return {
-      chartData:           null,
-      resourceSubtype:     null,
-      tooltipsDescription: null,
-      iconsDisplay:        PSAIconsDisplay,
+      chartData:       null,
+      resourceSubtype: null,
 
       // Set by fetch
       hasGraph:        null,
@@ -380,8 +376,6 @@ export default {
       <DetailTop
         v-if="isView && isDetail"
         :value="liveModel"
-        :tooltips="tooltipsDescription"
-        :icons="iconsDisplay"
       />
     </Masthead>
 

--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -46,7 +46,7 @@ export default {
   },
 
   data() {
-    return { toggler: true };
+    return { toggler: false };
   },
 
   computed: {
@@ -65,24 +65,24 @@ export default {
   <div :class="containerClass">
     <div class="labels">
       <div class="labels__header">
-        <h2>
+        <h3>
           <t k="labels.labels.title" />
-        </h2>
+        </h3>
         <ToggleSwitch
-          v-if="value.getPSALabels.length"
+          v-if="value.hasSystemLabels"
           v-model="toggler"
           name="label-system-toggle"
           :on-label="t('labels.labels.show')"
         />
       </div>
-      <p class="helper-text mt-20 mb-20">
+      <p class="helper-text mt-10 mb-10">
         <t k="labels.labels.description" />
       </p>
       <div :class="sectionClass">
         <KeyValue
           key="labels"
           :value="value.labels"
-          :protected-keys="value.getPSALabels"
+          :protected-keys="value.systemLabels || []"
           :toggle-filter="toggler"
           :add-label="t('labels.addLabel')"
           :mode="mode"
@@ -114,7 +114,6 @@ export default {
   &__header {
     display: flex;
     justify-content: space-between;
-    margin-bottom: 1em;
   }
 }
 </style>

--- a/shell/edit/namespace.vue
+++ b/shell/edit/namespace.vue
@@ -105,9 +105,6 @@ export default {
       return !this.isSingleHarvester;
     },
 
-    labels() {
-      return this.value?.metadata?.labels || {};
-    },
   },
 
   watch: {
@@ -228,7 +225,6 @@ export default {
         />
       </Tab>
       <Tab
-        v-if="!isView"
         name="labels-and-annotations"
         label-key="generic.labelsAndAnnotations"
         :weight="-1"
@@ -246,7 +242,7 @@ export default {
         :label="t('podSecurityAdmission.label')"
       >
         <PodSecurityAdmission
-          :labels="labels"
+          :labels="value.labels"
           :mode="mode"
           @updateLabels="value.setLabels($event)"
         />

--- a/shell/models/namespace.js
+++ b/shell/models/namespace.js
@@ -11,7 +11,7 @@ import SteveModel from '@shell/plugins/steve/steve-class';
 import Vue from 'vue';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/product/harvester-manager';
 import { hasPSALabels, getPSATooltipsDescription, getPSALabels } from '@shell/utils/pod-security-admission';
-import { PSALabelsNamespaceVersion } from '@shell/config/pod-security-admission';
+import { PSAIconsDisplay, PSALabelsNamespaceVersion } from '@shell/config/pod-security-admission';
 
 const OBSCURE_NAMESPACE_PREFIX = [
   'c-', // cluster namespace
@@ -213,26 +213,40 @@ export default class Namespace extends SteveModel {
     Vue.set(this.metadata.annotations, RESOURCE_QUOTA, JSON.stringify(value));
   }
 
+  get detailTopTooltips() {
+    return this.psaTooltipsDescription;
+  }
+
+  get detailTopIcons() {
+    return PSAIconsDisplay;
+  }
+
   /**
    * Check if resource contains PSA labels
    */
-  get hasPSALabels() {
+  get hasSystemLabels() {
     return hasPSALabels(this);
   }
 
-  get getPSALabelsNamespaceVersion() {
-    return PSALabelsNamespaceVersion;
+  get filteredSystemLabels() {
+    return Object.entries(this.labels).reduce((res, [key, value]) => {
+      if (!PSALabelsNamespaceVersion.includes(key)) {
+        res[key] = value;
+      }
+
+      return res;
+    }, {});
   }
 
   /**
-     * Generate list of present keys which can be filtered based on existing label keys and system keys
-     */
-  get getPSALabels() {
+   * Generate list of present keys which can be filtered based on existing label keys and system keys
+   */
+  get systemLabels() {
     return getPSALabels(this);
   }
 
-  getPSATooltipsDescription(value = this) {
-    return getPSATooltipsDescription(value);
+  get psaTooltipsDescription() {
+    return getPSATooltipsDescription(this);
   }
 
   // Preserve the project label - ensures we preserve project when cloning a namespace


### PR DESCRIPTION
DetailTop
- Remove PSA specific code from generic component

ResourceDetail
- Remove PSA specific code from generic component
- Remove plumbing for descriptions and icons from parent component to DetailTop

Labels&Annotations component
- Default `show system labels` to off
- Ensure size of `Labels` and `Annotations` titles are the same
- Improve padding
- Remove PSA specific code from generic component
- Removed un-needed margin-bottom
- Fixed white page error when viewing non-namespace resources

Project/Namespace List
- Improve padlock icon alignment
- Improve spacing around PSA list in tooltip (this will pop up often)

PodSecurtyAdmission settings component
- Improved alignment on PSA checkbox

General Improvements
- Always show Labels&Annotations on Namespace config (view) page

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->